### PR TITLE
Searcher: show file path in relative

### DIFF
--- a/src/org/omegat/core/search/Searcher.java
+++ b/src/org/omegat/core/search/Searcher.java
@@ -356,9 +356,10 @@ public class Searcher {
             // Search TM entries, unless we search for date or author.
             // They are not loaded from external TM, so skip the search in
             // that case.
+            Path projectRoot = Paths.get(m_project.getProjectProperties().getProjectRoot());
             if (!searchExpression.searchAuthor && !searchExpression.searchDateAfter && !searchExpression.searchDateBefore) {
                 for (Map.Entry<String, ExternalTMX> tmEn : m_project.getTransMemories().entrySet()) {
-                    final String fileTM = tmEn.getKey();
+                    final String fileTM = searchExpression.fileNames ? projectRoot.relativize(Paths.get(tmEn.getKey())).toString() : null;
                     searchEntries(tmEn.getValue().getEntries(), ENTRY_ORIGIN_TRANSLATION_MEMORY, fileTM);
                     checkStop.checkInterrupted();
                 }


### PR DESCRIPTION
- When filepath option is on in search dialog, a result pane will show
file paths in relative manner.
- Fix a behavior that TM search show paths even when filepath option is off.
- Address [BUGS#1098](https://sourceforge.net/p/omegat/bugs/1098/) and [BUGS#1099](https://sourceforge.net/p/omegat/bugs/1099/)

Signed-off-by: Hiroshi Miura <miurahr@linux.com>

<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Build and release changes
- [ ] Other (describe below)

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ -->

- Link: <!-- Paste link here -->
- Title: <!-- Paste title here -->

## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
